### PR TITLE
Start the web server from dslstat's configured snapshot directory

### DIFF
--- a/root/root/init.sh
+++ b/root/root/init.sh
@@ -18,8 +18,9 @@ x11vnc -forever -usepw -display $DISPLAY -shared &
 PID2=$!
 sleep 5
 
-mkdir -p /root/.dslstats/webserver/
-cd /root/.dslstats/webserver/
+webserverdir=`cat /config/dslstats.ini | grep Snapshotdir | awk -F"=" '{print $2 "/webserver"}'`
+mkdir -p $webserverdir
+cd $webserverdir
 
 python -m SimpleHTTPServer 8080 &
 PID3=$!


### PR DESCRIPTION
dslstats writes the webserver files to a subdirectory of the snapshot directory. I recently reconfigured my installation of dslstats to write to `config` so as to persist the snapshots. However, the web server that's part of the container assumes that the default snapshot directory is being used and tries to serve files from there.

This PR pulls the snapshot directory from the dslstats config and starts the webserver from there. I've tested this against my existing installation, but not against a fresh installation.